### PR TITLE
Generate OSGi metadata for the Java binding

### DIFF
--- a/bindings/ppmp-java-binding/pom.xml
+++ b/bindings/ppmp-java-binding/pom.xml
@@ -13,9 +13,11 @@
     <groupId>org.eclipse.iot.unide.ppmp</groupId>
     <artifactId>ppmp-java-binding</artifactId>
     <version>1.0.0-SNAPSHOT</version>
+    <packaging>bundle</packaging>
 
     <properties>
         <jackson.version>2.8.2</jackson.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -33,6 +35,15 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>3.3.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
     </build>
 
     <dependencies>


### PR DESCRIPTION
This change makes an OSGi bundle out of the 'ppm-java-binding' bundle by
using the Maven Bundle Plugin.

This change also sets the source encoding property to UTF-8 in order to fix the build maven build warning. 

Signed-off-by: Jens Reimann <jreimann@redhat.com>