### PR TITLE
Update documentation and ppmp-schema version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,47 @@ For installing the Unide server and binding implementations use Maven.
 
 ## Installation
 
-Run `mvn clean install`
+Install the `ppmp-java-binding` dependency
+
+    git clone https://github.com/eclipse/unide.java.git
+    cd unide.java
+    mvn clean install
+
+Then install this repo
+
+    git clone https://github.com/eclipse/unide.git
+    cd unide
+    mvn clean install
+
+On success
+
+    ...
+    [INFO] Reactor Summary:
+    [INFO]
+    [INFO] ppmp-schema 3.0.0-SNAPSHOT ......................... SUCCESS [  1.058 s]
+    [INFO] Unide 0.3.0-SNAPSHOT ............................... SUCCESS [  0.003 s]
+    [INFO] unide-servers ...................................... SUCCESS [  0.003 s]
+    [INFO] unide-server 0.3.0-SNAPSHOT ........................ SUCCESS [ 28.981 s]
+    ...
+
+Build the jars
+
+    mvn package -Dmaven.test.skip=true
+
+Create a test configuration `application_conf.json` for the REST server
+
+    {
+      "http.port": 8090,
+      "persistence.enable": false
+    }
+
+Start the REST server
+
+    java -jar ./servers/rest/target/ppmp-server-0.3.0-SNAPSHOT.jar -conf application_conf.json
+
+Visit http://localhost:8090/
+
+
+## References
+
+- https://www.eclipse.org/unide/blog/2018/3/26/Release-0.2.0/

--- a/servers/rest/pom.xml
+++ b/servers/rest/pom.xml
@@ -33,7 +33,7 @@
 		<jsonvaldiator.version>0.1.7</jsonvaldiator.version>
 		<jackson.version>2.8.6</jackson.version>
 		<ppmpjavabinding.version>0.3.0-SNAPSHOT</ppmpjavabinding.version>
-		<ppmpschema.version>2.0.0</ppmpschema.version>
+		<ppmpschema.version>3.0.0-SNAPSHOT</ppmpschema.version>
 		<log4j.version>1.2.17</log4j.version>
 		<postgres.version>42.1.4</postgres.version>
 		<jaxb.version>2.3.0</jaxb.version>


### PR DESCRIPTION
When building `ppmp-schema` the version in the repo was higher than the pom. This change updates the pom file and adds some setup instructions. 